### PR TITLE
CC-1485 LogConfigs not exposed via service-migration SDK

### DIFF
--- a/servicemigration/__init__.py
+++ b/servicemigration/__init__.py
@@ -9,3 +9,4 @@ from healthcheck import HealthCheck
 from addressconfig import AddressConfig
 from instancelimits import InstanceLimits
 from configfile import ConfigFile
+from logconfig import LogConfig

--- a/servicemigration/logconfig.py
+++ b/servicemigration/logconfig.py
@@ -1,0 +1,59 @@
+import copy
+
+import logtag
+
+
+default = {
+    "path": "",
+    "type": "",
+    "filters": [],
+    "LogTags": [
+        copy.deepcopy(logtag.default),
+        ],
+}
+
+
+def deserialize(data):
+    """
+    Deserialize a list of LogConfig entities.
+    """
+    if not data:
+        return []
+    logconfigs = []
+    for d in data:
+        lc = LogConfig()
+        lc._LogConfig__data = d
+        lc.path = d.get("path", d.get("Path"))
+        lc.logType = d.get("type", d.get("Type"))
+        lc.filters = d.get("filters", d.get("Filters"))
+        lc.logTags = logtag.deserialize(d.get("LogTags", []))
+        logconfigs.append(lc)
+    return logconfigs
+
+
+def serialize(logconfigs):
+    """
+    Serialize a list of LogConfig entities.
+    """
+    data = []
+    for lc in logconfigs:
+        d = copy.deepcopy(lc._LogConfig__data)
+        d["path"] = lc.path
+        d["type"] = lc.logType
+        d["filters"] = lc.filters
+        d["LogTags"] = logtag.serialize(lc.logTags)
+        data.append(d)
+    return data
+
+
+class LogConfig(object):
+    """
+    A collection of path and type info, filters, and tags.
+    """
+
+    def __init__(self, path="", logType="", filters=None, logTags=None):
+        self.__data = copy.deepcopy(default)
+        self.path = path
+        self.logType = logType
+        self.filters = filters or []
+        self.logTags = logTags or []

--- a/servicemigration/logtag.py
+++ b/servicemigration/logtag.py
@@ -1,0 +1,51 @@
+import copy
+
+
+default = {
+    "Name": "", 
+    "Value": "",
+}
+
+
+def deserialize(data):
+    """
+    Deserializes a list of LogTags.
+    """
+    if not data:
+        return []
+    tags = []
+    for datum in data:
+        tag = LogTag()
+        tag._LogTag__data = datum
+        if datum.get("Name"):
+            tag.name = datum["Name"]
+        if datum.get("Value"):
+            tag.value = datum["Value"]
+        tags.append(tag)
+    return tags
+
+
+def serialize(tags):
+    """
+    Serializes a single LogTag.
+    """
+    data = []
+    for tag in tags:
+        datum = copy.deepcopy(tag._LogTag__data)
+        datum.update({
+            "Name": tag.name,
+            "Value": tag.value,
+        })
+        data.append(datum)
+    return data
+
+
+class LogTag(object):
+    """
+    Wraps a single LogTag.
+    """
+
+    def __init__(self, name=None, value=None):
+        self.__data = copy.deepcopy(default)
+        self.name = name
+        self.value = value

--- a/servicemigration/service.py
+++ b/servicemigration/service.py
@@ -6,6 +6,7 @@ import healthcheck
 import instancelimits
 import configfile
 import command
+import logconfig
 import monitoringprofile
 
 RESTART = -1
@@ -31,6 +32,7 @@ def deserialize(data):
     service.configFiles = configfile.deserialize(data.get("OriginalConfigs", {}))
     service.monitoringProfile = monitoringprofile.deserialize(data.get("MonitoringProfile", {}))
     service.tags = data["Tags"][:] if data.get("Tags") is not None else []
+    service.logConfigs = logconfig.deserialize(data.get("LogConfigs", []))
     return service
 
 def serialize(service):
@@ -50,6 +52,7 @@ def serialize(service):
     data["OriginalConfigs"] = configfile.serialize(service.configFiles)
     data["MonitoringProfile"] = monitoringprofile.serialize(service.monitoringProfile)
     data["Tags"] = service.tags[:]
+    data["LogConfigs"] = logconfig.serialize(service.logConfigs)
     return data
 
 
@@ -59,9 +62,9 @@ class Service():
     """
 
     def __init__(self, name="", description="", startup="",
-        desiredState=STOP, endpoints=[], commands=[], volumes=[], 
-        healthChecks=[], instanceLimits=None, configFiles=[],
-        monitoringProfile=None, tags=[]):
+        desiredState=STOP, endpoints=None, commands=None, volumes=None,
+        healthChecks=None, instanceLimits=None, configFiles=None,
+        monitoringProfile=None, tags=None, logConfigs=None):
         """
         Internal use only. Do not call to create a service.
         """
@@ -70,14 +73,15 @@ class Service():
         self.description = description
         self.startup = startup
         self.desiredState = desiredState
-        self.endpoints = endpoints
-        self.commands = commands
-        self.volumes = volumes
-        self.healthChecks = healthChecks
+        self.endpoints = endpoints or []
+        self.commands = commands or []
+        self.volumes = volumes or []
+        self.healthChecks = healthChecks or []
         self.instanceLimits = instancelimits.InstanceLimits() if instanceLimits is None else instanceLimits
-        self.configFiles = configFiles
+        self.configFiles = configFiles or []
         self.monitoringProfile = monitoringProfile
-        self.tags = tags
+        self.tags = tags or []
+        self.logConfigs = logConfigs or []
 
     def clone(self):
         cl = copy.deepcopy(self)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -573,6 +573,73 @@ class ServiceTest(unittest.TestCase):
         svcs = filter(lambda s: "unlikely_tag_1" in s.tags and "unlikely_tag_2" in s.tags, ctx.services)
         self.assertEqual(len(svcs), 1)
 
+    def tests_logconfigs_add(self):
+        """
+        Tests adding a new file to a service's LogConfigs.
+        """
+        ctx = sm.ServiceContext(INFILENAME)
+        svc = filter(lambda x: x.description == "Zope server", ctx.services)[0]
+        self.assertEqual(len(svc.logConfigs), 3)
+        svc.logConfigs.append(sm.LogConfig(path="/opt/zenoss/log/honk.log",
+                                           logType="honk"))
+        ctx.commit(OUTFILENAME)
+        ctx = sm.ServiceContext(OUTFILENAME)
+        svc = filter(lambda x: x.description == "Zope server", ctx.services)[0]
+
+        if not "honk" in [hc.logType for hc in svc.logConfigs]:
+            raise ValueError("Failed to alter logconfigs.")
+        for lc in svc.logConfigs:
+            if lc.logType == "honk":
+                self.assertEqual(lc.path, "/opt/zenoss/log/honk.log")
+        self.assertEqual(len(svc.logConfigs), 4)
+
+    def tests_logconfigs_remove(self):
+        """
+        Tests removing a file from a service's LogConfigs.
+        """
+        ctx = sm.ServiceContext(INFILENAME)
+        svc = filter(lambda x: x.description == "Zope server", ctx.services)[0]
+        self.assertEqual(len(svc.logConfigs), 3)
+
+        no_audits = filter(lambda x: x.logType != 'zenossaudit', svc.logConfigs)
+        self.assertEqual(len(no_audits), 2)
+        svc.logConfigs = no_audits
+
+        ctx.commit(OUTFILENAME)
+        ctx = sm.ServiceContext(OUTFILENAME)
+        svc = filter(lambda x: x.description == "Zope server", ctx.services)[0]
+
+        if "zenossaudit" in [hc.logType for hc in svc.logConfigs]:
+            raise ValueError("Failed to alter logconfigs.")
+        self.assertEqual(len(svc.logConfigs), 2)
+
+    def tests_logconfigs_alter(self):
+        """
+        Tests changing the LogConfigs of a service.
+        """
+        ctx = sm.ServiceContext(INFILENAME)
+        svc = filter(lambda x: x.description == "Zope server", ctx.services)[0]
+        self.assertEqual(len(svc.logConfigs), 3)
+        for lc in svc.logConfigs:
+            if lc.logType == 'zenossaudit':
+                # Add or update logtag "foo" to "bar".
+                for tag in lc.logTags:
+                    if tag.name == 'foo':
+                        tag.value = 'bar'
+                        break
+                else:
+                    lc.logTags.append(sm.logtag.LogTag(name="foo", value="bar"))
+                lc.filters.append('baz')
+
+        svc = filter(lambda x: x.description == "Zope server", ctx.services)[0]
+
+        audit = filter(lambda x: x.logType == 'zenossaudit', svc.logConfigs)[0]
+        footags = filter(lambda t: t.name == 'foo', audit.logTags)
+        self.assertEqual(len(footags), 1)
+        self.assertEqual(footags[0].value, 'bar', "Failed ot alter logconfigs.")
+        self.assertTrue('baz' in audit.filters, "Failed to alter logconfigs.")
+        self.assertEqual(len(svc.logConfigs), 3)
+
     def test_clone_service(self):
         """
         Tests cloning a service.


### PR DESCRIPTION
Exposes the LogConfigs section of a service definition to
be modified via the service-migration SDK.

Closes CC-1485