### PR TITLE
CC-1470 MetricConfigs not exposed by migration SDK

### DIFF
--- a/servicemigration/graphdatapoint.py
+++ b/servicemigration/graphdatapoint.py
@@ -6,6 +6,7 @@ default = {
     "expression": "",
     "fill": False,
     "format": "%d",
+    "id": "",
     "legend": "",
     "metric": "",
     "metricSource": "r",

--- a/servicemigration/metrics.py
+++ b/servicemigration/metrics.py
@@ -2,6 +2,12 @@ import copy
 
 default = {
     "ID": "",
+    "Name": "",
+    "Description": "",
+    "Unit": "",
+    "Counter": False,
+    "ResetValue": 0,
+    "BuiltIn": False,
 }
 
 
@@ -12,8 +18,15 @@ def deserialize(data):
     metrics = []
     for d in data:
         m = Metric()
-        m._Metric__data = data
+        m._Metric__data = d
         m.ID = d["ID"]
+        m.name = d.get("Name")
+        m.description = d.get("Description")
+        m.unit = d.get("Unit")
+        m.counter = d.get("Counter", False)
+        m.resetValue = d.get("ResetValue", 0)
+        m.builtin = d.get("Builtin", False)
+        metrics.append(m)
     return metrics
 
 
@@ -23,8 +36,14 @@ def serialize(metrics):
     """
     data = []
     for m in metrics:
-        d = copy.deepcopy(mc._Metric__data)
+        d = copy.deepcopy(m._Metric__data)
         d["ID"] = m.ID
+        d["Name"] = m.name
+        d["Description"] = m.description
+        d["Unit"] = m.unit
+        d["Counter"] = m.counter
+        d["ResetValue"] = m.resetValue
+        d["BuiltIn"] = m.builtin
         data.append(d)
     return data
     
@@ -33,6 +52,13 @@ class Metric(object):
     """
     Wraps a single Metric object.
     """
-    def __init__(self, ID=""):
+    def __init__(self, ID="", name="", description="", unit="", counter=False,
+                 resetValue=0, builtin=False):
         self.__data = copy.deepcopy(default)
         self.ID = ID
+        self.name = name
+        self.description = description
+        self.unit = unit
+        self.counter = counter
+        self.resetValue = resetValue
+        self.builtin = builtin

--- a/servicemigration/monitoringprofile.py
+++ b/servicemigration/monitoringprofile.py
@@ -8,6 +8,9 @@ default = {
     "MetricConfigs": [
         copy.deepcopy(metricconfig.default),
         ],
+    "GraphConfigs": [
+        copy.deepcopy(graphconfig.default),
+        ],
 }
 
 


### PR DESCRIPTION
Bugfix follow-up to #28

This change keeps MonitoringProfile.MetricConfigs from
parsing its Metrics into empty values, and also fixes
the __data field of Metrics parsed.

Metrics are also expanded so they can be selected and
modified by more fields than their unique IDs. Their
deserialized data is now correct

Closes CC-1470