### PR TITLE
Fix graphdatapoint.type mapping

### DIFF
--- a/servicemigration/graphdatapoint.py
+++ b/servicemigration/graphdatapoint.py
@@ -39,7 +39,7 @@ def deserialize(data):
         p.metricSource = d.get("metricSource")
         p.rate = d.get("rate", False)
         p.rateOptions = d.get("rateOptions")
-        p.pointType = d.get("pointType")
+        p.pointType = d.get("type")
         datapoints.append(p)
     return datapoints
 
@@ -65,7 +65,7 @@ def serialize(datapoints):
         d["metricSource"] = p.metricSource
         d["rate"] = p.rate
         d["rateOptions"] = p.rateOptions
-        d["pointType"] = p.pointType
+        d["type"] = p.pointType
         data.append(d)
     return data
     

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -513,6 +513,7 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(len(monpro.graphConfigs), 0)
         gc = sm.monitoringprofile.graphconfig.GraphConfig(
             graphID="widgets")
+        gc.datapoints = [sm.graphdatapoint.GraphDatapoint(pointType="dot")]
         monpro.graphConfigs.append(gc)
         ctx.commit(OUTFILENAME)
         ctx = sm.ServiceContext(OUTFILENAME)
@@ -522,6 +523,8 @@ class ServiceTest(unittest.TestCase):
         gc_ids = [gc.graphID for gc in monpro.graphConfigs]
         self.assertEqual(len(gc_ids), 1)
         self.assertTrue('widgets' in gc_ids)
+        self.assertEqual(len(monpro.graphConfigs[0].datapoints), 1)
+        self.assertEqual(monpro.graphConfigs[0].datapoints[0].pointType, "dot")
 
     def test_graphconfig_modify(self):
         """
@@ -532,6 +535,7 @@ class ServiceTest(unittest.TestCase):
         monpro = svc.monitoringProfile
         self.assertEqual(len(monpro.graphConfigs), 1)
         monpro.graphConfigs[0].description = "Modified description"
+        monpro.graphConfigs[0].datapoints[0].pointType = "dot"
         ctx.commit(OUTFILENAME)
         ctx = sm.ServiceContext(OUTFILENAME)
         svc = filter(lambda x: x.name == "CentralQuery", ctx.services)[0]
@@ -539,6 +543,8 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(len(monpro.graphConfigs), 1)
         desc = monpro.graphConfigs[0].description
         self.assertEqual(desc, "Modified description")
+        pt = monpro.graphConfigs[0].datapoints[0].pointType
+        self.assertEqual(pt, "dot")
 
     def test_tags_filter(self):
         """


### PR DESCRIPTION
Graphdata migrations weren't making changes to datapoint types
because the field was misnamed in serialize and deserialize.

This change maps the data model to the correct servicedef field.