### PR TITLE
SVC-1051: Prevent zenpacks from overwritting the version of other services

### DIFF
--- a/servicemigration/context.py
+++ b/servicemigration/context.py
@@ -105,7 +105,9 @@ class ServiceContext(object):
         unmodifiedServices = []
         for svc in self.services:
             serial = service.serialize(svc)
-            serial["Version"] = self.version
+            # Only update version if it is non-empty
+            if self.version:
+                serial["Version"] = self.version
             if serial["ID"] == "new-service":
                 addedServices.append(serial)
             elif serial["ID"] in self._dirty:

--- a/servicemigration/context.py
+++ b/servicemigration/context.py
@@ -105,9 +105,6 @@ class ServiceContext(object):
         unmodifiedServices = []
         for svc in self.services:
             serial = service.serialize(svc)
-            # Only update version if it is non-empty
-            if self.version:
-                serial["Version"] = self.version
             if serial["ID"] == "new-service":
                 addedServices.append(serial)
             elif serial["ID"] in self._dirty:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -25,12 +25,14 @@ class ContextTest(unittest.TestCase):
     def test_ctx_versioning(self):
         """
         Tests ServiceContext versioning
+        Which has been removed
         """
         ctx = sm.ServiceContext(INFILENAME)
+        self.assertEqual(ctx.version, "")
         ctx.version = "foo.bar.baz"
         ctx.commit(OUTFILENAME)
         ctx = sm.ServiceContext(OUTFILENAME)
-        self.assertEqual(ctx.version, "foo.bar.baz")
+        self.assertEqual(ctx.version, "")
 
     def test_sdk_versioning_major_big(self):
         major = int(sm.version.API_VERSION.split('.')[0]) + 1


### PR DESCRIPTION
Prevent Zenpacks that use ServiceContext Commit() to add a new service from setting the version of other services to empty string