### PR TITLE
add environment to service to support ZEN-28346 work

### DIFF
--- a/servicemigration/service.py
+++ b/servicemigration/service.py
@@ -44,7 +44,7 @@ def deserialize(data):
     service.changeOptions = data.get("ChangeOptions", [])
     service.hostPolicy = data.get("HostPolicy", "")
     service.privileged = data.get("Privileged", False)
-    service.environment = data["Environment"][:] if data.get("Envrionment") is not None else []
+    service.environment = data["Environment"][:] if data.get("Environment") is not None else []
     return service
 
 def serialize(service):

--- a/servicemigration/service.py
+++ b/servicemigration/service.py
@@ -44,6 +44,7 @@ def deserialize(data):
     service.changeOptions = data.get("ChangeOptions", [])
     service.hostPolicy = data.get("HostPolicy", "")
     service.privileged = data.get("Privileged", False)
+    service.environment = data["Environment"][:] if data.get("Envrionment") is not None else []
     return service
 
 def serialize(service):
@@ -74,6 +75,7 @@ def serialize(service):
     data["ChangeOptions"] = service.changeOptions
     data["HostPolicy"] = service.hostPolicy
     data["Privileged"] = service.privileged
+    data["Environment"] = service.environment[:]
     return data
 
 
@@ -88,7 +90,7 @@ class Service(object):
         configFiles=None, monitoringProfile=None, tags=None, logConfigs=None,
         prereqs=None, ramCommitment=None, imageID = "", emergencyShutdownLevel=0,
         startLevel=0, instances=0, changeOptions=None, hostPolicy="",
-        privileged=False):
+        privileged=False, environment=None):
         """
         Internal use only. Do not call to create a service.
         """
@@ -116,6 +118,7 @@ class Service(object):
         self.changeOptions = changeOptions
         self.hostPolicy = hostPolicy
         self.privileged = privileged
+        self.environment = environment or []
 
     def clone(self):
         cl = copy.deepcopy(self)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -725,3 +725,29 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(clone.description, redis.description)
         self.assertEqual(len(ctx.services), 35)
 
+
+    def test_environment_add(self):
+        """
+        Tests adding environment to a service.
+        """
+        ctx = sm.ServiceContext(INFILENAME)
+        svc = filter(lambda s: s.name == "opentsdb", ctx.services)[0]
+        svc.environment = ["unlikely_env_1", "unlikely_env_2"]
+        ctx.commit(OUTFILENAME)
+        ctx = sm.ServiceContext(OUTFILENAME)
+        svc = filter(lambda s: s.name == "opentsdb", ctx.services)[0]
+        self.assertEqual(len(svc.environment), 2)
+
+    def test_environment_filter(self):
+        """
+        Tests filtering on environment
+        """
+        ctx = sm.ServiceContext(INFILENAME)
+        svc = filter(lambda s: s.name == "opentsdb", ctx.services)[0]
+        svc.environment = ["unlikely_env_1", "unlikely_env_2"]
+        ctx.commit(OUTFILENAME)
+        ctx = sm.ServiceContext(OUTFILENAME)
+        svcs = filter(lambda s: "unlikely_env_1" in s.environment and "unlikely_env_2" in s.environment, ctx.services)
+        self.assertEqual(len(svcs), 1)
+
+


### PR DESCRIPTION
For ZEN-28346, we need to add items to the 'Environment' section of the opentsdb/reader/writer service definitions. Adding support for the Environment section to service.py